### PR TITLE
Improve support for BC canvases

### DIFF
--- a/_docs/language-reference/bounded-context.md
+++ b/_docs/language-reference/bounded-context.md
@@ -99,11 +99,11 @@ With the _knowledgeLevel_ attribute you define the knowledge level of the bounde
  * CONCRETE
  * META
  
-This attribute allow you to define the knowledge level according to the DDD Knowledge Level pattern. See [this page](/docs/knowledge-level/).
+This attribute allows you to define the knowledge level according to the DDD Knowledge Level pattern. See [this page](/docs/knowledge-level/).
 
 ### Support for Bounded Context Canvases
 
-To support Bounded Context Canvases, these optional fields are part of `BoundedContext`:
+To support Bounded Context Canvases, use these optional fields in `BoundedContext`:
 - `businessModel`. One of:
   * UNDEFINED
   * REVENUE
@@ -117,7 +117,7 @@ To support Bounded Context Canvases, these optional fields are part of `BoundedC
   * PRODUCT
   * COMMODITY
 
-Some resources:
+Further reading on bounded context canvases:
 - [_The Bounded Context Canvas_](https://github.com/ddd-crew/bounded-context-canvas)
 - [_Bounded Context Canvas V3: Simplifications and Additions_](https://medium.com/nick-tune-tech-strategy-blog/bounded-context-canvas-v2-simplifications-and-additions-229ed35f825f)
 - [_DDD re-distilled_](https://yoan-thirion.gitbook.io/knowledge-base/software-architecture/ddd-re-distilled)

--- a/_docs/language-reference/bounded-context.md
+++ b/_docs/language-reference/bounded-context.md
@@ -101,6 +101,27 @@ With the _knowledgeLevel_ attribute you define the knowledge level of the bounde
  
 This attribute allow you to define the knowledge level according to the DDD Knowledge Level pattern. See [this page](/docs/knowledge-level/).
 
+### Support for Bounded Context Canvases
+
+To support Bounded Context Canvases, these optional fields are part of `BoundedContext`:
+- `businessModel`. One of:
+  * UNDEFINED
+  * REVENUE
+  * ENGAGEMENT
+  * COMPLIANCE
+  * COST_REDUCTION
+- `evolution`. One of:
+  * UNDEFINED
+  * GENESIS
+  * CUSTOM_BUILT
+  * PRODUCT
+  * COMMODITY
+
+Some resources:
+- [_The Bounded Context Canvas_](https://github.com/ddd-crew/bounded-context-canvas)
+- [_Bounded Context Canvas V3: Simplifications and Additions_](https://medium.com/nick-tune-tech-strategy-blog/bounded-context-canvas-v2-simplifications-and-additions-229ed35f825f)
+- [_DDD re-distilled_](https://yoan-thirion.gitbook.io/knowledge-base/software-architecture/ddd-re-distilled)
+
 ### Team _realizes_ Bounded Context
 If your bounded context is of the type TEAM, you can specify which bounded context the team implements by using the _realizes_ keyword. The following example illustrates this:
 

--- a/_docs/language-reference/bounded-context.md
+++ b/_docs/language-reference/bounded-context.md
@@ -104,7 +104,7 @@ This attribute allows you to define the knowledge level according to the DDD Kno
 ### Support for Bounded Context Canvases
 
 To support Bounded Context Canvases, use these optional fields in `BoundedContext`:
-- `businessModel`. One of:
+- `businessModel`. Free text; common values include:
   * UNDEFINED
   * REVENUE
   * ENGAGEMENT

--- a/_docs/language-reference/bounded-context.md
+++ b/_docs/language-reference/bounded-context.md
@@ -121,6 +121,7 @@ Further reading on bounded context canvases:
 - [_The Bounded Context Canvas_](https://github.com/ddd-crew/bounded-context-canvas)
 - [_Bounded Context Canvas V3: Simplifications and Additions_](https://medium.com/nick-tune-tech-strategy-blog/bounded-context-canvas-v2-simplifications-and-additions-229ed35f825f)
 - [_DDD re-distilled_](https://yoan-thirion.gitbook.io/knowledge-base/software-architecture/ddd-re-distilled)
+- [_What I talk about when I talk about Domain-Driven Design by Andrew Harmel-Law_](https://youtu.be/6nrRfCkeAKU)
 
 ### Team _realizes_ Bounded Context
 If your bounded context is of the type TEAM, you can specify which bounded context the team implements by using the _realizes_ keyword. The following example illustrates this:


### PR DESCRIPTION
Improve support for bounded context canvases with "business model" and "evolution" fields.

There are other fields to add (such as "ubiquitous language" and "business decision"): they are out of scope for this PR.

This PR depends on:
- https://github.com/ContextMapper/context-mapper-dsl/pull/323 (grammar)
- -https://github.com/ContextMapper/context-mapper-examples/pull/25 (example)